### PR TITLE
feat: add retired/disabled status to vault schema

### DIFF
--- a/schema/vault.json
+++ b/schema/vault.json
@@ -17,17 +17,19 @@
     "retired": {
       "type": "boolean"
     },
-    "depositDisabled": {
-      "type": "boolean"
+    "deposit": {
+      "type": "object",
+      "properties": {
+        "disabled": { "type": "boolean" },
+        "message": { "type": "string" }
+      }
     },
-    "depositDisabledMessage": {
-      "type": "boolean"
-    },
-    "withdrawDisabled": {
-      "type": "boolean"
-    },
-    "withdrawDisabledMessage": {
-      "type": "boolean"
+    "withdraw": {
+      "type": "object",
+      "properties": {
+        "disabled": { "type": "boolean" },
+        "message": { "type": "string" }
+      }
     },
     "apy": {
       "type": "object",

--- a/schema/vault.json
+++ b/schema/vault.json
@@ -14,6 +14,21 @@
     "promoted": {
       "type": "boolean"
     },
+    "retired": {
+      "type": "boolean"
+    },
+    "depositDisabled": {
+      "type": "boolean"
+    },
+    "depositDisabledMessage": {
+      "type": "boolean"
+    },
+    "withdrawDisabled": {
+      "type": "boolean"
+    },
+    "withdrawDisabledMessage": {
+      "type": "boolean"
+    },
     "apy": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
As suggested by @x48-crypto, added the following properties to vault schema:

- retired
- depositDisabled
- depositDisabledMessage
- withdrawDisabled
- withdrawDisabledMessage