### PR TITLE
feat: add utilized protocols

### DIFF
--- a/data/strategies/Convex.json
+++ b/data/strategies/Convex.json
@@ -30,5 +30,6 @@
         "0xCc39eC658Eedb7e44f5aeD9B5192219982D2c9e5",
         "0x8e87e65Cb28c069550012f92d5470dB6EB6897c0"
     ],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/PoolTogether.json
+++ b/data/strategies/PoolTogether.json
@@ -7,5 +7,6 @@
         "0x6EB00860260CF51623737e17579Db797d71cd337",
         "0x57e848A6915455a7e77CF0D55A1474bEFd9C374d"
     ],
+    "protocols": ["Pool Together"],
     "authors": []
 }

--- a/data/strategies/SingleSided.json
+++ b/data/strategies/SingleSided.json
@@ -9,5 +9,6 @@
         "0xf840d061E83025F4cD6610AE5DDebCcA43327f9f",
         "0x30010039Ea4a0c4fa1Ac051E8aF948239678353d"
     ],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/StrategyAH2Earn.json
+++ b/data/strategies/StrategyAH2Earn.json
@@ -7,5 +7,6 @@
         "0x82292B8035873d7DD8a96767F6b3F885564aa919",
         "0x7D960F3313f3cB1BBB6BF67419d303597F3E2Fa8"
     ],
+    "protocols": ["Alpha Homora v2"],
     "authors": []
 }

--- a/data/strategies/StrategyIdleidleCOMP.json
+++ b/data/strategies/StrategyIdleidleCOMP.json
@@ -7,5 +7,6 @@
         "0x2E1ad896D3082C52A5AE7Af307131DE7a37a46a0",
         "0x01b54c320d6B3057377cbc71d953d1BBa84df44e"
     ],
+    "protocols": ["Idle Finance"],
     "authors": []
 }

--- a/data/strategies/StrategyMakerDelegate.json
+++ b/data/strategies/StrategyMakerDelegate.json
@@ -10,5 +10,6 @@
         "0x0E5397B8547C128Ee20958286436b7BC3f9faAa4",
         "0x4730D10703155Ef4a448B17b0eaf3468fD4fb02d"
     ],
+    "protocols": ["MakerDAO"],
     "authors": []
 }

--- a/data/strategies/StrategyRook.json
+++ b/data/strategies/StrategyRook.json
@@ -7,5 +7,6 @@
         "0xB361a3E75Bc2Ae6c8A045b3A43E2B0c9aD890d48",
         "0xbC0F2FF495eE2eb74A145EDAA457FA4Fa310DAC5"
     ],
+    "protocols": ["KeeperDAO"],
     "authors": []
 }

--- a/data/strategies/VoterProxy.json
+++ b/data/strategies/VoterProxy.json
@@ -29,5 +29,6 @@
         "0x94fA3A90E680f6b866545C904D1dc9DEe6416de9",
         "0x23a09D84e50fF3fDFa270308851443734b0a4b6D"
     ],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/AaveLender_unique/AaveLenderLINKBorrowerSUSD.json
+++ b/data/strategies/individual_strats/AaveLender_unique/AaveLenderLINKBorrowerSUSD.json
@@ -3,5 +3,6 @@
     "name": "Aave Borrow sUSD Strategy",
     "description": "Supplies {{token}} to [AAVE](https://app.aave.com/home) to generate interest and earn staked AAVE tokens. Once unlocked, earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy. This strategy also borrows tokens against {{token}}. Borrowed tokens are then deposited into corresponding yVault to generate yield.",
     "addresses": ["0x906f0a6f23e7160eB0927B0903ab80b5E3f3950D"],
+    "protocols": ["Aave"],
     "authors": []
 }

--- a/data/strategies/individual_strats/AaveLender_unique/AaveLenderWBTCBorrowerUSDC.json
+++ b/data/strategies/individual_strats/AaveLender_unique/AaveLenderWBTCBorrowerUSDC.json
@@ -3,5 +3,6 @@
     "name": "Aave Borrow USDC Strategy",
     "description": "Supplies {{token}} to [AAVE](https://app.aave.com/home) to generate interest and earn staked AAVE tokens. Once unlocked, earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy. This strategy also borrows tokens against {{token}}. Borrowed tokens are then deposited into corresponding yVault to generate yield.",
     "addresses": ["0xAE159E657712CC68C8A28B6749eC044a7fEABe21"],
+    "protocols": ["Aave"],
     "authors": []
 }

--- a/data/strategies/individual_strats/AaveLender_unique/AaveWETHLenderUSDTBorrower.json
+++ b/data/strategies/individual_strats/AaveLender_unique/AaveWETHLenderUSDTBorrower.json
@@ -3,5 +3,6 @@
     "name": "Aave Borrow USDT Strategy",
     "description": "Supplies {{token}} to [AAVE](https://app.aave.com/home) to generate interest and earn staked AAVE tokens. Once unlocked, earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy. This strategy also borrows tokens against {{token}}. Borrowed tokens are then deposited into corresponding yVault to generate yield.",
     "addresses": ["0xd28b508EA08f14A473a5F332631eA1972cFd7cC0"],
+    "protocols": ["Aave"],
     "authors": []
 }

--- a/data/strategies/individual_strats/DAOFeeClaim.json
+++ b/data/strategies/individual_strats/DAOFeeClaim.json
@@ -3,5 +3,6 @@
     "name": "Curve DAO Fee Claim Strategy",
     "description": "Converts {{token}} into yveCRV and earns a continuous share of [Curve Finance](https://curve.fi) fees. Earned [3Crv](https://curve.fi/3pool) (Curve's 3pool LP token) fees can be claimed every Friday.",
     "addresses": [],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/Generalized one-sided/StrategyeCurveWETHSingleSided.json
+++ b/data/strategies/individual_strats/Generalized one-sided/StrategyeCurveWETHSingleSided.json
@@ -6,5 +6,6 @@
         "0xda988eBb26F505246C59Ba26514340B634F9a7a2",
         "0x37770F958447fFa1571fc9624BFB3d673161f37F"
     ],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/Generalized one-sided/StrategysteCurveWETHSingleSided.json
+++ b/data/strategies/individual_strats/Generalized one-sided/StrategysteCurveWETHSingleSided.json
@@ -6,5 +6,6 @@
         "0x2886971eCAF2610236b4869f58cD42c115DFb47A",
         "0xC5e385f7Dad49F230AbD53e21b06aA0fE8dA782D"
     ],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/IBLevComp.json
+++ b/data/strategies/individual_strats/IBLevComp.json
@@ -6,5 +6,6 @@
         "0x77b7CD137Dd9d94e7056f78308D7F65D2Ce68910",
         "0xE68A8565B4F837BDa10e2e917BFAaa562e1cD143"
     ],
+    "protocols": ["Compound Finance", "Iron Bank"],
     "authors": []
 }

--- a/data/strategies/individual_strats/SingleSided_unique/SingleSidedCrvsUSD - saave.json
+++ b/data/strategies/individual_strats/SingleSided_unique/SingleSidedCrvsUSD - saave.json
@@ -3,6 +3,6 @@
     "name": "sUSD sAAVE Curve Pool Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) to earn CRV. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x74b3E5408B1c29E571BbFCd94B09D516A4d81f36"],
-    "protocol": ["Curve Finance"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/SingleSided_unique/SingleSidedCrvsUSD - saave.json
+++ b/data/strategies/individual_strats/SingleSided_unique/SingleSidedCrvsUSD - saave.json
@@ -3,5 +3,6 @@
     "name": "sUSD sAAVE Curve Pool Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) to earn CRV. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x74b3E5408B1c29E571BbFCd94B09D516A4d81f36"],
+    "protocol": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/SingleSided_unique/SingleSidedCrvsUSD - susd2.json
+++ b/data/strategies/individual_strats/SingleSided_unique/SingleSidedCrvsUSD - susd2.json
@@ -3,5 +3,6 @@
     "name": "sUSDv2 Curve Pool Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) to earn CRV. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x95eA1643699F8DE347975F31CA8d03eCC507616c"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/Strategy1INCHGovernance.json
+++ b/data/strategies/individual_strats/Strategy1INCHGovernance.json
@@ -3,5 +3,6 @@
     "name": "Governance Staking Strategy",
     "description": "Stakes {{token}} on [1inch DAO](https://app.1inch.io/#/1/dao/governance) to collect governance rewards. Rewards are harvested and deposited back into the strategy.",
     "addresses": ["0xB12F6A5776EDd2e923fD1Ce93041B2000A22dDc7"],
+    "protocols": ["1inch"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyGenericLevCompFarm.json
+++ b/data/strategies/individual_strats/StrategyGenericLevCompFarm.json
@@ -6,5 +6,6 @@
         "0x4031afd3B0F71Bace9181E554A9E680Ee4AbE7dF",
         "0x4d7d4485fd600c61d840ccbec328bfd76a050f87"
     ],
+    "protocols": ["Compound Finance", "dYdX"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyIdleidleRAIYield.json
+++ b/data/strategies/individual_strats/StrategyIdleidleRAIYield.json
@@ -3,5 +3,6 @@
     "name": "Idle RAI Strategy",
     "description": "Supplies {{token}} on [Idle Finance](https://idle.finance) to earn IDLE and RAI. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x5D411D2cde10e138d68517c42bE2808C90c22026"],
+    "protocols": ["Idle Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - a.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - a.json
@@ -6,5 +6,6 @@
         "0x2f87c5e8396F0C41b86aad4F3C8358aB21681952",
         "0x5e882c9f00209315e049B885B9b3dfbEe60D80A4"
     ],
+    "protocols": ["Aave"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ad.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ad.json
@@ -3,6 +3,6 @@
     "name": "dYdX / C.R.E.A.M. Lender Optimizer",
     "description": "Supplies {{token}} to [dYdX](https://margin.dydx.exchange/markets/overview) and [C.R.E.A.M.](https://app.cream.finance) to generate interest. The proportions are adjusted each time the strategy calls harvest.",
     "addresses": ["0x32b8C26d0439e1959CEa6262CBabC12320b384c4"],
-    "protocols": ["dYdX", "C.R.E.A.M. Finance"],
+    "protocols": ["C.R.E.A.M. Finance", "dYdX"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ad.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ad.json
@@ -3,6 +3,6 @@
     "name": "dYdX / C.R.E.A.M. Lender Optimizer",
     "description": "Supplies {{token}} to [dYdX](https://margin.dydx.exchange/markets/overview) and [C.R.E.A.M.](https://app.cream.finance) to generate interest. The proportions are adjusted each time the strategy calls harvest.",
     "addresses": ["0x32b8C26d0439e1959CEa6262CBabC12320b384c4"],
-    "protocol": ["dYdX", "C.R.E.A.M. Finance"],
+    "protocols": ["dYdX", "C.R.E.A.M. Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ad.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ad.json
@@ -3,5 +3,6 @@
     "name": "dYdX / C.R.E.A.M. Lender Optimizer",
     "description": "Supplies {{token}} to [dYdX](https://margin.dydx.exchange/markets/overview) and [C.R.E.A.M.](https://app.cream.finance) to generate interest. The proportions are adjusted each time the strategy calls harvest.",
     "addresses": ["0x32b8C26d0439e1959CEa6262CBabC12320b384c4"],
+    "protocol": ["dYdX", "C.R.E.A.M. Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ah.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ah.json
@@ -6,5 +6,6 @@
         "0xeE697232DF2226c9fB3F02a57062c4208f287851",
         "0xec2DB4A1Ad431CC3b102059FA91Ba643620F0826"
     ],
+    "protocol": ["Alpha Homora"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ah.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ah.json
@@ -6,6 +6,6 @@
         "0xeE697232DF2226c9fB3F02a57062c4208f287851",
         "0xec2DB4A1Ad431CC3b102059FA91Ba643620F0826"
     ],
-    "protocol": ["Alpha Homora"],
+    "protocols": ["Alpha Homora"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - c.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - c.json
@@ -7,6 +7,6 @@
         "0x6a97FC93e39b3f792f1fD6e01565ff412B002D20",
         "0x86eD4F77d40182b8686a25e125FB3f5a04203CaA"
     ],
-    "protocol": ["C.R.E.A.M. Finance"],
+    "protocols": ["C.R.E.A.M. Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - c.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - c.json
@@ -7,5 +7,6 @@
         "0x6a97FC93e39b3f792f1fD6e01565ff412B002D20",
         "0x86eD4F77d40182b8686a25e125FB3f5a04203CaA"
     ],
+    "protocol": ["C.R.E.A.M. Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ca.json
+++ b/data/strategies/individual_strats/StrategyLenderYieldOptimiser - ca.json
@@ -7,5 +7,6 @@
         "0xe9bD008A97e362F7C501F6F5532A348d2e6B8131",
         "0x695F00450641968b264e1d2e98dFF3e013143a37"
     ],
+    "protocols": ["Aave", "C.R.E.A.M. Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategySynthetixSusdMinter.json
+++ b/data/strategies/individual_strats/StrategySynthetixSusdMinter.json
@@ -3,5 +3,6 @@
     "name": "Synthetix Minter Strategy",
     "description": "Stakes {{token}} on [Synthetix](https://staking.synthetix.io/) and mints sUSD. The newly minted sUSD is then deposited into the sUSD yVault to generate yield. Generated yield, weekly {{token}} fees and vested rewards (when claimable) are harvested, sold for more {{token}} which is deposited back into the strategy. **Rewards on staked {{token}} are locked for 1 year**.",
     "addresses": ["0xFB5F4E0656ebfF31743e674d324554fd185e1c4b"],
+    "protocols": ["Synthetix"],
     "authors": []
 }

--- a/data/strategies/individual_strats/StrategyYearnVECRV.json
+++ b/data/strategies/individual_strats/StrategyYearnVECRV.json
@@ -3,5 +3,6 @@
     "name": "Compounding veCRV Strategy",
     "description": "Accepts {{token}} to earn a continuous share of [Curve Finance](https://curve.fi) fees. Earned [3Crv](https://curve.fi/3pool) (Curve's 3pool LP token) fees are harvested, swapped for more {{token}} which is deposited back into the strategy. Swap happens either via market-buy or mint, depending which is more capital efficient.",
     "addresses": ["0x2923a58c1831205C854DBEa001809B194FDb3Fa5"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexFRAX3CRV-f.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexFRAX3CRV-f.json
@@ -3,6 +3,6 @@
     "name": "Convex FRAX Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn FXS, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x8c312B63Bc4000f61E1C4df4868A3A1f09b31A73"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexFRAX3CRV-f.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexFRAX3CRV-f.json
@@ -3,5 +3,6 @@
     "name": "Convex FRAX Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn FXS, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x8c312B63Bc4000f61E1C4df4868A3A1f09b31A73"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/Convexa3CRV.json
+++ b/data/strategies/individual_strats/convex_unique/Convexa3CRV.json
@@ -3,5 +3,6 @@
     "name": "Convex a3CRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn stkAAVE, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xAC4AE0B06C913dF4608dB60E2571a8e91b74C619"],
+    "protocol": ["Convex Finance", "Curve Finance"]
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/Convexa3CRV.json
+++ b/data/strategies/individual_strats/convex_unique/Convexa3CRV.json
@@ -3,6 +3,6 @@
     "name": "Convex a3CRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn stkAAVE, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xAC4AE0B06C913dF4608dB60E2571a8e91b74C619"],
-    "protocol": ["Convex Finance", "Curve Finance"]
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/Convexa3CRV.json
+++ b/data/strategies/individual_strats/convex_unique/Convexa3CRV.json
@@ -3,6 +3,6 @@
     "name": "Convex a3CRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn stkAAVE, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xAC4AE0B06C913dF4608dB60E2571a8e91b74C619"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexalUSD3CRV-f.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexalUSD3CRV-f.json
@@ -3,6 +3,6 @@
     "name": "Convex alUSD 3CRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn ALCX, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xf8Fb278DeeaF30Ff3F6326d928A61eA8b9397d16"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexalUSD3CRV-f.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexalUSD3CRV-f.json
@@ -3,5 +3,6 @@
     "name": "Convex alUSD 3CRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn ALCX, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xf8Fb278DeeaF30Ff3F6326d928A61eA8b9397d16"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexankrCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexankrCRV.json
@@ -3,5 +3,6 @@
     "name": "Convex ANKR 3CRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn ANKR, ONX, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xB194dCFF4E11d26919Ce3B3255F69aEca5951e88"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexankrCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexankrCRV.json
@@ -3,6 +3,6 @@
     "name": "Convex ANKR 3CRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn ANKR, ONX, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xB194dCFF4E11d26919Ce3B3255F69aEca5951e88"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexcrvPlain3andSUSD.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexcrvPlain3andSUSD.json
@@ -3,6 +3,6 @@
     "name": "Convex sUSD Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn SNX, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xFA773b91b59B0895877c769000b9824b46b13a20"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexcrvPlain3andSUSD.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexcrvPlain3andSUSD.json
@@ -3,5 +3,6 @@
     "name": "Convex sUSD Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn SNX, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xFA773b91b59B0895877c769000b9824b46b13a20"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexoBTCsbtcCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexoBTCsbtcCRV.json
@@ -3,5 +3,6 @@
     "name": "Convex oBTC/sBTC Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn BOR, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xDb2D3F149270630382D4E6B4dbCd47e665D78D76"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexoBTCsbtcCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexoBTCsbtcCRV.json
@@ -3,6 +3,6 @@
     "name": "Convex oBTC/sBTC Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn BOR, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xDb2D3F149270630382D4E6B4dbCd47e665D78D76"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexpBTCsbtcCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexpBTCsbtcCRV.json
@@ -3,6 +3,6 @@
     "name": "Convex pBTC/sBTC Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn PNT, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x7b5cb4694b0A299ED2F65db7d87B286461549e84"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexpBTCsbtcCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexpBTCsbtcCRV.json
@@ -3,5 +3,6 @@
     "name": "Convex pBTC/sBTC Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn PNT, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x7b5cb4694b0A299ED2F65db7d87B286461549e84"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexrCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexrCRV.json
@@ -3,6 +3,6 @@
     "name": "Convex rCRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn FIS, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x8E4AA2E00694Adaf37f0311651262671f4d7Ac16"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/ConvexrCRV.json
+++ b/data/strategies/individual_strats/convex_unique/ConvexrCRV.json
@@ -3,5 +3,6 @@
     "name": "Convex rCRV Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn FIS, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x8E4AA2E00694Adaf37f0311651262671f4d7Ac16"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/StrategyConvexstETH.json
+++ b/data/strategies/individual_strats/convex_unique/StrategyConvexstETH.json
@@ -3,6 +3,6 @@
     "name": "Convex stETH Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn LDO, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x6C0496fC55Eb4089f1Cf91A4344a2D56fAcE51e3"],
-    "protocol": ["Convex Finance", "Curve Finance"],
+    "protocols": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/convex_unique/StrategyConvexstETH.json
+++ b/data/strategies/individual_strats/convex_unique/StrategyConvexstETH.json
@@ -3,5 +3,6 @@
     "name": "Convex stETH Strategy",
     "description": "Supplies {{token}} to [Convex Finance](https://www.convexfinance.com/stake) to earn LDO, CRV and CVX. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x6C0496fC55Eb4089f1Cf91A4344a2D56fAcE51e3"],
+    "protocol": ["Convex Finance", "Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/CurveFRAX3CRV-fVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/CurveFRAX3CRV-fVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts FRAX Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn FRAX and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xb622F17e1ba8C51b9BD760Fb37994a55b1e5CD85"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/Curvea3CRVVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/Curvea3CRVVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts a3CRV Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn stkAAVE and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xB11FC91DF59ADc604485f1B25ABa1F96A685473f"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/CurvealUSD3CRV-fVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/CurvealUSD3CRV-fVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts alUSD Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn ALCX and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x31CD90D60516ED18750bA49b2C9d1053190F40d9"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/CurveankrCRVVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/CurveankrCRVVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts ANKR Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) to earn ANKR, ONX and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x32EF165F2ABbdbE7dcC25B86EdB14a2C0dc52571"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/CurvecrvPlain3andSUSDVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/CurvecrvPlain3andSUSDVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts sUSD Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn SNX and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x9730F52AB5BcEc960bE41b0fE4913a09c0B57066"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/CurveoBTCsbtcCRVVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/CurveoBTCsbtcCRVVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts oBTC Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn BOR and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x24579b82E06aBe25C8ffC4Ee6C2dB676e57F1a32"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/CurvepBTCsbtcCRVVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/CurvepBTCsbtcCRVVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts sBTC Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn PNT and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x04a6E58aAd4Ed8053Ba436B00C02A8a000639e93"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/CurverCRVVoterProxy.json
+++ b/data/strategies/individual_strats/voterproxy_unique/CurverCRVVoterProxy.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts rCRV Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn FIS and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x16468a3999d931Dd6b6ffA0086Cf195D6C5BDAFA"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/voterproxy_unique/StrategystETHCurve.json
+++ b/data/strategies/individual_strats/voterproxy_unique/StrategystETHCurve.json
@@ -3,5 +3,6 @@
     "name": "Curve Boosts stETH Strategy",
     "description": "Supplies {{token}} to [Curve Finance](https://curve.fi) and stakes it in gauge to earn LDO and enhanced CRV rewards thanks to [locked CRV boost](https://resources.curve.fi/guides/boosting-your-crv-rewards). Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0xebfC9451d19E8dbf36AAf547855b4dC789CA793C"],
+    "protocols": ["Curve Finance"],
     "authors": []
 }

--- a/data/strategies/individual_strats/yvWBTCStratMMV1.json
+++ b/data/strategies/individual_strats/yvWBTCStratMMV1.json
@@ -3,5 +3,6 @@
     "name": "Mushroom Finance wBTC Strategy",
     "description": "Supplies {{token}} to [Mushroom Finance](https://mushrooms.finance) {{token}} Vault to earn MM. Earned tokens are harvested, sold for more {{token}} which is deposited back into the strategy.",
     "addresses": ["0x53a65c8e238915c79a1e5C366Bc133162DBeE34f"],
+    "protocols": ["Mushroom Finance"],
     "authors": []
 }

--- a/data/strategies/vesper.json
+++ b/data/strategies/vesper.json
@@ -6,5 +6,6 @@
         "0x8198815871a45A5a883d083B7B105927eb9919D8",
         "0x416647Ddee169156878DC46CD565dee99413c262"
     ],
+    "protocols": ["Vesper Finance"],
     "authors": []
 }


### PR DESCRIPTION
Protocols listed are those that the strategy EXPLICITLY utilizes. If a strategy deposits into another vault, the protocols that the vault uses are not listed. Likewise, this doesn't cover protocols associated with tokens that the strategies are exposed to. 