### PR TITLE
[WEB-1105-115] fix: update APY for curve:USDPax, RAI, crveth, 3eur, and dola

### DIFF
--- a/data/vaults/1/0x2D5D4869381C4Fce34789BC1D38aCCe747E295AE.json
+++ b/data/vaults/1/0x2D5D4869381C4Fce34789BC1D38aCCe747E295AE.json
@@ -5,7 +5,7 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 21.5,
-  "apyTypeOverride": "n/a",
+  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0x5AB64C599FcC59f0f2726A300b03166A395578Da.json
+++ b/data/vaults/1/0x5AB64C599FcC59f0f2726A300b03166A395578Da.json
@@ -5,7 +5,7 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 24.5,
-  "apyTypeOverride": "n/a",
+  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0x6A5468752f8DB94134B6508dAbAC54D3b45efCE6.json
+++ b/data/vaults/1/0x6A5468752f8DB94134B6508dAbAC54D3b45efCE6.json
@@ -5,7 +5,7 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 22.5,
-  "apyTypeOverride": "n/a",
+  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0xc97511a1dDB162C8742D39FF320CfDCd13fBcf7e.json
+++ b/data/vaults/1/0xc97511a1dDB162C8742D39FF320CfDCd13fBcf7e.json
@@ -5,7 +5,7 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 20.5,
-  "apyTypeOverride": "n/a",
+  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,


### PR DESCRIPTION
updated APY to say "new" instead of "n/a"