### PR TITLE
[WEB-1147-124] ci: pin yearn meta to the Crust Network(decentralized IPFS)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -44,3 +44,11 @@ jobs:
           cloudflare-secret: ${{ secrets.CLOUDFLARE_SECRET }}
           record-domain: yearn.network
           record-name: _dnslink.meta
+          
+      - name: Pin to Crust
+        uses: crustio/ipfs-crust-action@v2.0.6
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          cid: ${{ steps.upload.outputs.cidv1 }}
+          seeds: ${{ secrets.CRUST_SEEDS }}


### PR DESCRIPTION
To fix #144, I suggest the code change in this PR to include ipfs-crust-action. It will distribute yearn meta over Crust Network and get 100+ IPFS replicas.

Crust Network ([https://crust.network/](https://crust.network/)) is a decentralized storage network based on IPFS and Substrate, and it basically provides decentralized IPFS Pin service. Right now Crust is running and got 6000+ nodes joined in to provide IPFS storage ([https://medium.com/crustnetwork/a-new-breakthrough-in-distributed-storage-powered-by-intel-sgx-c1b9de773076](https://medium.com/crustnetwork/a-new-breakthrough-in-distributed-storage-powered-by-intel-sgx-c1b9de773076)). Crust is open source([https://github.com/crustio/crust](https://github.com/crustio/crust)).

If you need help with the account secret about the Crust Account, I'm happy to help. You can also prepare the account by yourself.