### PR TITLE
[WEB-1157-128] w override for four vaults

### DIFF
--- a/data/vaults/250/0x0446acaB3e0242fCf33Aa526f1c95a88068d5042.json
+++ b/data/vaults/250/0x0446acaB3e0242fCf33Aa526f1c95a88068d5042.json
@@ -4,7 +4,6 @@
   "hideAlways": false,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
-  "apyTypeOverride": "new",
   "order": 6,
   "migrationAvailable": false,
   "allowZapIn": false,

--- a/data/vaults/250/0xCe2Fc0bDc18BD6a4d9A725791A3DEe33F3a23BB7.json
+++ b/data/vaults/250/0xCe2Fc0bDc18BD6a4d9A725791A3DEe33F3a23BB7.json
@@ -4,7 +4,6 @@
   "hideAlways": false,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
-  "apyTypeOverride": "new",
   "order": 6,
   "migrationAvailable": false,
   "allowZapIn": false,

--- a/data/vaults/250/0xD3c19eB022CAC706c898D60d756bf1535d605e1d.json
+++ b/data/vaults/250/0xD3c19eB022CAC706c898D60d756bf1535d605e1d.json
@@ -4,7 +4,6 @@
   "hideAlways": false,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
-  "apyTypeOverride": "new",
   "order": 6,
   "migrationAvailable": false,
   "allowZapIn": false,

--- a/data/vaults/250/0xd817A100AB8A29fE3DBd925c2EB489D67F758DA9.json
+++ b/data/vaults/250/0xd817A100AB8A29fE3DBd925c2EB489D67F758DA9.json
@@ -4,7 +4,6 @@
   "hideAlways": false,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
-  "apyTypeOverride": "new",
   "order": 6,
   "migrationAvailable": false,
   "allowZapIn": false,


### PR DESCRIPTION
now that they have harvest data, remove APY overrides for CRV, WETH, WBTC, and SPELL