### PR TITLE
[WEB-1190-143] feat: remove new type override for curve vaults with working APY

### DIFF
--- a/data/vaults/1/0x5AB64C599FcC59f0f2726A300b03166A395578Da.json
+++ b/data/vaults/1/0x5AB64C599FcC59f0f2726A300b03166A395578Da.json
@@ -5,7 +5,6 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 24.5,
-  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0x801Ab06154Bf539dea4385a39f5fa8534fB53073.json
+++ b/data/vaults/1/0x801Ab06154Bf539dea4385a39f5fa8534fB53073.json
@@ -5,7 +5,6 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 51,
-  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0xBCBB5b54Fa51e7b7Dc920340043B203447842A6b.json
+++ b/data/vaults/1/0xBCBB5b54Fa51e7b7Dc920340043B203447842A6b.json
@@ -5,7 +5,6 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 51,
-  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0xc97511a1dDB162C8742D39FF320CfDCd13fBcf7e.json
+++ b/data/vaults/1/0xc97511a1dDB162C8742D39FF320CfDCd13fBcf7e.json
@@ -5,7 +5,6 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 20.5,
-  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0xd88dBBA3f9c4391Ee46f5FF548f289054db6E51C.json
+++ b/data/vaults/1/0xd88dBBA3f9c4391Ee46f5FF548f289054db6E51C.json
@@ -5,7 +5,6 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 10.5,
-  "apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,


### PR DESCRIPTION
show APYs for EURS-USDC, EURT-USD, 3EUR, USDPax, and DOLA curve vaults