### PR TITLE
[WEB-1266-155] fix: update scream.sh link 

### DIFF
--- a/data/strategies/250/LenderOptimizer.json
+++ b/data/strategies/250/LenderOptimizer.json
@@ -1,7 +1,7 @@
 {
   "$schema": "strategy",
   "name": "Lender Optimizer",
-  "description": "Supplies {{token}} to [Iron Bank](https://beta.yearn.finance/#/ironbank) or [Scream](scream.sh) whichever has the best yield to generate interest. Earned tokens are harvested, sold for more {{token}}, then deposited back into the strategy.",
+  "description": "Supplies {{token}} to [Iron Bank](https://beta.yearn.finance/#/ironbank) or [Scream](https://scream.sh) whichever has the best yield to generate interest. Earned tokens are harvested, sold for more {{token}}, then deposited back into the strategy.",
   "addresses": [
     "0x695A4a6e5888934828Cb97A3a7ADbfc71A70922D",
     "0xD0D1f041F93c0fF1091457618E529610C67A76de",


### PR DESCRIPTION
Current link points to "https://yearn.finance/scream.sh" due to missing "https://" prefix