### PR TITLE
[WEB-1313-160] fix: update curve webpage link

### DIFF
--- a/data/tokens/1/0x02d341CcB60fAaf662bC0554d13778015d1b285C.json
+++ b/data/tokens/1/0x02d341CcB60fAaf662bC0554d13778015d1b285C.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, and sUSD that are lent out to Aave, a decentralized money market on Ethereum.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/saave/",
   "tokenSymbolOverride": "crvSAAVE",
   "tokenNameOverride": "Curve sAave Pool"
 }

--- a/data/tokens/1/0x06325440D014e39736583c165C2963BA99fAf14E.json
+++ b/data/tokens/1/0x06325440D014e39736583c165C2963BA99fAf14E.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ETH and stETH, a token that represents staked ether in Lido, a decentralized ETH 2.0 staking platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/steth/",
   "tokenSymbolOverride": "crvSTETH",
   "tokenNameOverride": "Curve stETH Pool"
 }

--- a/data/tokens/1/0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3.json
+++ b/data/tokens/1/0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains WBTC, renBTC, and sBTC, and is the basis for all of Curve's BTC metapools. sBTC is synthetic BTC minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/sbtc/",
   "tokenSymbolOverride": "crvSBTC",
   "tokenNameOverride": "Curve sBTC Pool"
 }

--- a/data/tokens/1/0x194eBd173F6cDacE046C53eACcE9B953F28411d1.json
+++ b/data/tokens/1/0x194eBd173F6cDacE046C53eACcE9B953F28411d1.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains EURS and synthetic euro (sEUR) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/eurs/",
   "tokenSymbolOverride": "crvEURS",
   "tokenNameOverride": "Curve EURS Pool"
 }

--- a/data/tokens/1/0x19b080FE1ffA0553469D20Ca36219F17Fcf03859.json
+++ b/data/tokens/1/0x19b080FE1ffA0553469D20Ca36219F17Fcf03859.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ibEUR, a synthetic euro minted from the Iron Bank, and synthetic euro (sEUR) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/3/",
+  "website": "https://curve.fi/factory/3/",
   "tokenSymbolOverride": "crvIBEUR",
   "tokenNameOverride": "Curve ibEUR Pool"
 }

--- a/data/tokens/1/0x19b080FE1ffA0553469D20Ca36219F17Fcf03859.json
+++ b/data/tokens/1/0x19b080FE1ffA0553469D20Ca36219F17Fcf03859.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ibEUR, a synthetic euro minted from the Iron Bank, and synthetic euro (sEUR) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/3/",
   "tokenSymbolOverride": "crvIBEUR",
   "tokenNameOverride": "Curve ibEUR Pool"
 }

--- a/data/tokens/1/0x1AEf73d49Dedc4b1778d0706583995958Dc862e6.json
+++ b/data/tokens/1/0x1AEf73d49Dedc4b1778d0706583995958Dc862e6.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and Meta USD.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/musd/",
   "tokenSymbolOverride": "crvMUSD",
   "tokenNameOverride": "Curve mUSD Pool"
 }

--- a/data/tokens/1/0x2fE94ea3d5d4a175184081439753DE15AeF9d614.json
+++ b/data/tokens/1/0x2fE94ea3d5d4a175184081439753DE15AeF9d614.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains sBTC-Crv (sBTC, WBTC, and renBTC) and oBTC, an ERC-20 backed by native BTC via BoringDAO.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/obtc/",
   "tokenSymbolOverride": "crvOBTC",
   "tokenNameOverride": "Curve oBTC Pool"
 }

--- a/data/tokens/1/0x3A283D9c08E8b55966afb64C515f5143cf907611.json
+++ b/data/tokens/1/0x3A283D9c08E8b55966afb64C515f5143cf907611.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This crypto pool contains CVX and ETH. Please be aware that as crypto pools are composed of differently-priced assets, they are subject to impermanent loss.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/cvxeth/",
   "tokenSymbolOverride": "crvCVXETH",
   "tokenNameOverride": "Curve CVX-ETH Pool"
 }

--- a/data/tokens/1/0x3B3Ac5386837Dc563660FB6a0937DFAa5924333B.json
+++ b/data/tokens/1/0x3B3Ac5386837Dc563660FB6a0937DFAa5924333B.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, USDC, USDT, and BUSD that are lent out to various decentralized money markets on Ethereum.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/busd",
   "tokenSymbolOverride": "crvYBUSD",
   "tokenNameOverride": "Curve yBUSD Pool"
 }

--- a/data/tokens/1/0x3D229E1B4faab62F621eF2F6A610961f7BD7b23B.json
+++ b/data/tokens/1/0x3D229E1B4faab62F621eF2F6A610961f7BD7b23B.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This crypto pool contains both Stasis Euro (EURS) and USDC. Please be aware that as crypto pools are composed of differently-priced assets, they are subject to impermanent loss.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/eursusd",
   "tokenSymbolOverride": "crvEURSUSDC",
   "tokenNameOverride": "Curve EURS-USDC Pool"
 }

--- a/data/tokens/1/0x3F1B0278A9ee595635B61817630cC19DE792f506.json
+++ b/data/tokens/1/0x3F1B0278A9ee595635B61817630cC19DE792f506.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ibAUD, a synthetic Australian dollar minted from the Iron Bank, and synthetic Australian dollar (sAUD) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/factory/29/",
   "tokenSymbolOverride": "crvIBAUD",
   "tokenNameOverride": "Curve ibAUD Pool"
 }

--- a/data/tokens/1/0x3Fb78e61784C9c637D560eDE23Ad57CA1294c14a.json
+++ b/data/tokens/1/0x3Fb78e61784C9c637D560eDE23Ad57CA1294c14a.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This curve pool contains EURN and EURT.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/factory/33",
   "tokenSymbolOverride": "crvEURN",
-  "tokenNameOverride": "Curve EURN Pool"
+  "tokenNameOverride": "Curve Neutrino EURN Pool"
 }

--- a/data/tokens/1/0x3a664Ab939FD8482048609f652f9a0B0677337B9.json
+++ b/data/tokens/1/0x3a664Ab939FD8482048609f652f9a0B0677337B9.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and DUSD.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/dusd/",
   "tokenSymbolOverride": "crvDUSD",
   "tokenNameOverride": "Curve DUSD Pool"
 }

--- a/data/tokens/1/0x3b6831c0077a1e44ED0a21841C3bC4dC11bCE833.json
+++ b/data/tokens/1/0x3b6831c0077a1e44ED0a21841C3bC4dC11bCE833.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This crypto pool contains DAI, USDC, USDT, and Euro Tether (EURT). Please be aware that as crypto pools are composed of differently-priced assets, they are subject to impermanent loss.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/eurtusd/",
   "tokenSymbolOverride": "crvEURTUSD",
   "tokenNameOverride": "Curve EURT-USD Pool"
 }

--- a/data/tokens/1/0x410e3E86ef427e30B9235497143881f717d93c2A.json
+++ b/data/tokens/1/0x410e3E86ef427e30B9235497143881f717d93c2A.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains sBTC-Crv (sBTC, WBTC, and renBTC) and Binance BTC, a wrapped BTC minted by Binance.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/bbtc/",
   "tokenSymbolOverride": "crvBBTC",
   "tokenNameOverride": "Curve BBTC Pool"
 }

--- a/data/tokens/1/0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c.json
+++ b/data/tokens/1/0x43b4FdFD4Ff969587185cDB6f0BD875c5Fc83f8c.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This factory metapool contains 3Crv (DAI, USDC, and USDT) and Alchemix USD.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/alusd",
   "tokenSymbolOverride": "crvALUSD",
   "tokenNameOverride": "Curve alUSD Pool"
 }

--- a/data/tokens/1/0x4807862AA8b2bF68830e4C8dc86D0e9A998e085a.json
+++ b/data/tokens/1/0x4807862AA8b2bF68830e4C8dc86D0e9A998e085a.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This factory metapool contains 3Crv (DAI, USDC, and USDT) and Binance USD, a regulated stablecoin issued by Paxos.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/busdv2",
   "tokenSymbolOverride": "crvBUSD",
   "tokenNameOverride": "Curve BUSD Pool"
 }

--- a/data/tokens/1/0x49849C98ae39Fff122806C06791Fa73784FB3675.json
+++ b/data/tokens/1/0x49849C98ae39Fff122806C06791Fa73784FB3675.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains WBTC and renBTC, an ERC-20 backed by native BTC via Ren's decentralized Darknodes.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/ren/",
   "tokenSymbolOverride": "crvRENBTC",
   "tokenNameOverride": "Curve renBTC Pool"
 }

--- a/data/tokens/1/0x4f3E8F405CF5aFC05D68142F3783bDfE13811522.json
+++ b/data/tokens/1/0x4f3E8F405CF5aFC05D68142F3783bDfE13811522.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and USDN.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/usdn",
   "tokenSymbolOverride": "crvUSDN",
   "tokenNameOverride": "Curve USDN Pool"
 }

--- a/data/tokens/1/0x5282a4eF67D9C33135340fB3289cc1711c13638C.json
+++ b/data/tokens/1/0x5282a4eF67D9C33135340fB3289cc1711c13638C.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, USDC, and USDT that are lent out to the Iron Bank, a decentralized money market on Ethereum launched collaboratively by C.R.E.A.M. and Yearn Finance.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/ib/",
   "tokenSymbolOverride": "crvIB",
   "tokenNameOverride": "Curve Iron Bank Pool"
 }

--- a/data/tokens/1/0x53a901d48795C58f485cBB38df08FA96a24669D5.json
+++ b/data/tokens/1/0x53a901d48795C58f485cBB38df08FA96a24669D5.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ETH and rETH, a token that represents staked ether in StaFi, an ETH 2.0 staking platform.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/reth/",
   "tokenSymbolOverride": "crvRETH",
   "tokenNameOverride": "Curve rETH Pool"
 }

--- a/data/tokens/1/0x55A8a39bc9694714E2874c1ce77aa1E599461E18.json
+++ b/data/tokens/1/0x55A8a39bc9694714E2874c1ce77aa1E599461E18.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains MIM and UST.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/48/",
   "tokenSymbolOverride": "crvMIM-UST",
   "tokenNameOverride": "Curve MIM-UST Pool"
 }

--- a/data/tokens/1/0x55A8a39bc9694714E2874c1ce77aa1E599461E18.json
+++ b/data/tokens/1/0x55A8a39bc9694714E2874c1ce77aa1E599461E18.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains MIM and UST.",
-  "website": "https://curve.fi/48/",
+  "website": "https://curve.fi/factory/48",
   "tokenSymbolOverride": "crvMIM-UST",
   "tokenNameOverride": "Curve MIM-UST Pool"
 }

--- a/data/tokens/1/0x5B3b5DF2BF2B6543f78e053bD91C4Bdd820929f1.json
+++ b/data/tokens/1/0x5B3b5DF2BF2B6543f78e053bD91C4Bdd820929f1.json
@@ -3,6 +3,6 @@
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. The curve gauge for this pool has been [killed](https://gov.curve.fi/t/the-curve-emergency-dao-has-killed-the-usdm-gauge/2307) by the Curve Emergeny DAO, thus this curve pool will not get any CRV rewards. This metapool contains 3Crv (DAI, USDC, and USDT) and USDM (USD Mochi).",
   "website": "https://curve.fi/factory/23",
-  "tokenSymbolOverride": "crvUSDMochi",
-  "tokenNameOverride": "Curve USDMochi Pool"
+  "tokenSymbolOverride": "crvUSDM",
+  "tokenNameOverride": "Curve USDM Pool"
 }

--- a/data/tokens/1/0x5B3b5DF2BF2B6543f78e053bD91C4Bdd820929f1.json
+++ b/data/tokens/1/0x5B3b5DF2BF2B6543f78e053bD91C4Bdd820929f1.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. The curve gauge for this pool has been [killed](https://gov.curve.fi/t/the-curve-emergency-dao-has-killed-the-usdm-gauge/2307) by the Curve Emergeny DAO, thus this curve pool will not get any CRV rewards. This metapool contains 3Crv (DAI, USDC, and USDT) and USDM (USD Mochi).",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/factory/23",
   "tokenSymbolOverride": "crvUSDMochi",
   "tokenNameOverride": "Curve USDMochi Pool"
 }

--- a/data/tokens/1/0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858.json
+++ b/data/tokens/1/0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and Huobi USD.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/husd/",
   "tokenSymbolOverride": "crvHUSD",
   "tokenNameOverride": "Curve HUSD Pool"
 }

--- a/data/tokens/1/0x5a6A4D54456819380173272A5E8E9B9904BdF41B.json
+++ b/data/tokens/1/0x5a6A4D54456819380173272A5E8E9B9904BdF41B.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and MIM, a decentralized stablecoin collateralized with yVaults and other yield-bearing tokens on Abracadabra.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/mim",
   "tokenSymbolOverride": "crvMIM",
   "tokenNameOverride": "Curve MIM Pool"
 }

--- a/data/tokens/1/0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd.json
+++ b/data/tokens/1/0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains sBTC-Crv (sBTC, WBTC, and renBTC) and tBTC, an ERC-20 supply-pegged to native BTC and overcollateralized with ETH.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/41/",
   "tokenSymbolOverride": "crvTBTC",
   "tokenNameOverride": "Curve tBTC Pool"
 }

--- a/data/tokens/1/0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd.json
+++ b/data/tokens/1/0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains sBTC-Crv (sBTC, WBTC, and renBTC) and tBTC, an ERC-20 supply-pegged to native BTC and overcollateralized with ETH.",
-  "website": "https://www.curve.fi/41/",
+  "website": "https://curve.fi/tbtc/",
   "tokenSymbolOverride": "crvTBTC",
   "tokenNameOverride": "Curve tBTC Pool"
 }

--- a/data/tokens/1/0x6BA5b4e438FA0aAf7C1bD179285aF65d13bD3D90.json
+++ b/data/tokens/1/0x6BA5b4e438FA0aAf7C1bD179285aF65d13bD3D90.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and RAI. Please be aware that as RAI is not pegged to $1, this pool may be subject to impermanent loss.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/rai",
   "tokenSymbolOverride": "crvRAI",
   "tokenNameOverride": "Curve RAI+3Crv Pool"
 }

--- a/data/tokens/1/0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490.json
+++ b/data/tokens/1/0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, USDC, and USDT. It is also known as 3Crv (or 3pool), and is the basis for all of Curve's stablecoin metapools.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/3pool/",
   "tokenSymbolOverride": "3crv",
   "tokenNameOverride": "Curve 3pool"
 }

--- a/data/tokens/1/0x7Eb40E450b9655f4B3cC4259BCC731c63ff55ae6.json
+++ b/data/tokens/1/0x7Eb40E450b9655f4B3cC4259BCC731c63ff55ae6.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and USDP, a synthetic stablecoin minted on Unit Protocol by overcollateralization of a variety of assets.",
-  "website": "https://curve.fi/factory/59",
+  "website": "https://curve.fi/usdp/",
   "tokenSymbolOverride": "crvUSDP",
   "tokenNameOverride": "Curve USDP Pool"
 }

--- a/data/tokens/1/0x7Eb40E450b9655f4B3cC4259BCC731c63ff55ae6.json
+++ b/data/tokens/1/0x7Eb40E450b9655f4B3cC4259BCC731c63ff55ae6.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and USDP, a synthetic stablecoin minted on Unit Protocol by overcollateralization of a variety of assets.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/factory/59",
   "tokenSymbolOverride": "crvUSDP",
   "tokenNameOverride": "Curve USDP Pool"
 }

--- a/data/tokens/1/0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2.json
+++ b/data/tokens/1/0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI and USDC lent out to Compound, a decentralized money market on Ethereum.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/compound",
   "tokenSymbolOverride": "crvCOMP",
   "tokenNameOverride": "Curve Compound Pool"
 }

--- a/data/tokens/1/0x8461A004b50d321CB22B7d034969cE6803911899.json
+++ b/data/tokens/1/0x8461A004b50d321CB22B7d034969cE6803911899.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ibKRW, a synthetic South Korean won minted from the Iron Bank, and synthetic South Korean won (sKRW) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/factory/2/",
   "tokenSymbolOverride": "crvIBKRW",
   "tokenNameOverride": "Curve ibKRW Pool"
 }

--- a/data/tokens/1/0x87650D7bbfC3A9F10587d7778206671719d9910D.json
+++ b/data/tokens/1/0x87650D7bbfC3A9F10587d7778206671719d9910D.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and OUSD, a decentralzed stablecoin backed 1:1 by other stablecoins.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/factory/9",
   "tokenSymbolOverride": "crvOUSD",
   "tokenNameOverride": "Curve OUSD Pool"
 }

--- a/data/tokens/1/0x8818a9bb44Fbf33502bE7c15c500d0C783B73067.json
+++ b/data/tokens/1/0x8818a9bb44Fbf33502bE7c15c500d0C783B73067.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ibJPY, a synthetic Japanese yen minted from the Iron Bank, and synthetic Japanese yen (sJPY) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/factory/28/",
   "tokenSymbolOverride": "crvIBJPY",
   "tokenNameOverride": "Curve ibJPY Pool"
 }

--- a/data/tokens/1/0x94e131324b6054c0D789b190b2dAC504e4361b53.json
+++ b/data/tokens/1/0x94e131324b6054c0D789b190b2dAC504e4361b53.json
@@ -1,8 +1,8 @@
 {
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
-  "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and UST.",
-  "website": "https://curve.fi/factory/53",
+  "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and UST. While still active, this pool also has a newer UST v2 Wormhole pool.",
+  "website": "https://curve.fi/ust/",
   "tokenSymbolOverride": "crvUST",
   "tokenNameOverride": "Curve UST Pool"
 }

--- a/data/tokens/1/0x94e131324b6054c0D789b190b2dAC504e4361b53.json
+++ b/data/tokens/1/0x94e131324b6054c0D789b190b2dAC504e4361b53.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and UST.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/factory/53",
   "tokenSymbolOverride": "crvUST",
   "tokenNameOverride": "Curve UST Pool"
 }

--- a/data/tokens/1/0x97E2768e8E73511cA874545DC5Ff8067eB19B787.json
+++ b/data/tokens/1/0x97E2768e8E73511cA874545DC5Ff8067eB19B787.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and USDK.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/usdk/",
   "tokenSymbolOverride": "crvUSDK",
   "tokenNameOverride": "Curve USDK Pool"
 }

--- a/data/tokens/1/0x9D0464996170c6B9e75eED71c68B99dDEDf279e8.json
+++ b/data/tokens/1/0x9D0464996170c6B9e75eED71c68B99dDEDf279e8.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains CRV, Curve's native governance token, and cvxCRV, Convex's tradable version of vote-escrowed CRV (veCRV).",
-  "website": "https://www.curve.fi/22/",
+  "website": "https://curve.fi/factory/22/",
   "tokenSymbolOverride": "crvCVXCRV",
   "tokenNameOverride": "Curve cvxCRV Pool"
 }

--- a/data/tokens/1/0x9D0464996170c6B9e75eED71c68B99dDEDf279e8.json
+++ b/data/tokens/1/0x9D0464996170c6B9e75eED71c68B99dDEDf279e8.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains CRV, Curve's native governance token, and cvxCRV, Convex's tradable version of vote-escrowed CRV (veCRV).",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/22/",
   "tokenSymbolOverride": "crvCVXCRV",
   "tokenNameOverride": "Curve cvxCRV Pool"
 }

--- a/data/tokens/1/0x9c2C8910F113181783c249d8F6Aa41b51Cde0f0c.json
+++ b/data/tokens/1/0x9c2C8910F113181783c249d8F6Aa41b51Cde0f0c.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ibCHF, a synthetic Swiss franc minted from the Iron Bank, and synthetic Swiss franc (sCHF) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/factory/31",
   "tokenSymbolOverride": "crvIBCHF",
   "tokenNameOverride": "Curve ibCHF Pool"
 }

--- a/data/tokens/1/0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c.json
+++ b/data/tokens/1/0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ETH and sETH, a synthetic ETH minted via the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/seth",
   "tokenSymbolOverride": "crvSETH",
   "tokenNameOverride": "Curve sETH Pool"
 }

--- a/data/tokens/1/0xAA5A67c256e27A5d80712c51971408db3370927D.json
+++ b/data/tokens/1/0xAA5A67c256e27A5d80712c51971408db3370927D.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and DOLA, a synthetic USD stablecoin that can be minted by using other assets on Inverse Finance (https://www.inverse.finance) as collateral.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/factory/27/",
   "tokenSymbolOverride": "crvDOLA",
   "tokenNameOverride": "Curve DOLA Pool"
 }

--- a/data/tokens/1/0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89.json
+++ b/data/tokens/1/0xBaaa1F5DbA42C3389bDbc2c9D2dE134F5cD0Dc89.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains FEI, FRAX, and alUSD, three decentralized dollar-pegged stablecoins.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/factory/57/",
   "tokenSymbolOverride": "crvD3POOL",
   "tokenNameOverride": "Curve d3pool"
 }

--- a/data/tokens/1/0xC25a3A3b969415c80451098fa907EC722572917F.json
+++ b/data/tokens/1/0xC25a3A3b969415c80451098fa907EC722572917F.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, USDC, USDT, and synthetic USD (sUSD) minted on the Synthetix platform. ",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/susdv2/",
   "tokenSymbolOverride": "crvSUSD",
   "tokenNameOverride": "Curve sUSD Pool"
 }

--- a/data/tokens/1/0xC2Ee6b0334C261ED60C72f6054450b61B8f18E35.json
+++ b/data/tokens/1/0xC2Ee6b0334C261ED60C72f6054450b61B8f18E35.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and RSV.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/rsv/",
   "tokenSymbolOverride": "crvRSV",
   "tokenNameOverride": "Curve RSV Pool"
 }

--- a/data/tokens/1/0xC4C319E2D4d66CcA4464C0c2B32c9Bd23ebe784e.json
+++ b/data/tokens/1/0xC4C319E2D4d66CcA4464C0c2B32c9Bd23ebe784e.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ETH and alETH (Alchemix ETH).",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/factory/38/",
   "tokenSymbolOverride": "crvalETH",
   "tokenNameOverride": "Curve alETH Pool"
 }

--- a/data/tokens/1/0xCEAF7747579696A2F0bb206a14210e3c9e6fB269.json
+++ b/data/tokens/1/0xCEAF7747579696A2F0bb206a14210e3c9e6fB269.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and UST.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/factory/53/",
   "tokenSymbolOverride": "crvUST-W",
   "tokenNameOverride": "Curve UST Wormhole Pool"
 }

--- a/data/tokens/1/0xD2967f45c4f384DEEa880F807Be904762a3DeA07.json
+++ b/data/tokens/1/0xD2967f45c4f384DEEa880F807Be904762a3DeA07.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and Gemini USD, a regulated stablecoin issued by the US exchange, Gemini.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/gusd/",
   "tokenSymbolOverride": "crvGUSD",
   "tokenNameOverride": "Curve GUSD Pool"
 }

--- a/data/tokens/1/0xD6Ac1CB9019137a896343Da59dDE6d097F710538.json
+++ b/data/tokens/1/0xD6Ac1CB9019137a896343Da59dDE6d097F710538.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ibGBP, a synthetic pound sterling minted from the Iron Bank, and synthetic pound sterling (sGBP) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/factory/30/",
   "tokenSymbolOverride": "crvIBGBP",
   "tokenNameOverride": "Curve ibGBP Pool"
 }

--- a/data/tokens/1/0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8.json
+++ b/data/tokens/1/0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, USDC, USDT, and Paxos USD (PAX). ",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/pax/",
   "tokenSymbolOverride": "crvPAX",
   "tokenNameOverride": "Curve PAX Pool"
 }

--- a/data/tokens/1/0xDE5331AC4B3630f94853Ff322B66407e0D6331E8.json
+++ b/data/tokens/1/0xDE5331AC4B3630f94853Ff322B66407e0D6331E8.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains sBTC-Crv (sBTC, WBTC, and renBTC) and pBTC, which is redeemable for native BTC at any time via pToken's network of secure sandboxes.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/pbtc/",
   "tokenSymbolOverride": "crvPBTC",
   "tokenNameOverride": "Curve pBTC Pool"
 }

--- a/data/tokens/1/0xEcd5e75AFb02eFa118AF914515D6521aaBd189F1.json
+++ b/data/tokens/1/0xEcd5e75AFb02eFa118AF914515D6521aaBd189F1.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This factory metapool contains 3Crv (DAI, USDC, and USDT) and TrueUSD.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/tusd/",
   "tokenSymbolOverride": "crvTUSD",
   "tokenNameOverride": "Curve TUSD Pool"
 }

--- a/data/tokens/1/0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA.json
+++ b/data/tokens/1/0xEd279fDD11cA84bEef15AF5D39BB4d4bEE23F0cA.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This factory metapool contains 3Crv (DAI, USDC, and USDT) and Liquity USD, a synthetic USD stablecoin collateralized with Ether.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/lusd/",
   "tokenSymbolOverride": "crvLUSD",
   "tokenNameOverride": "Curve LUSD Pool"
 }

--- a/data/tokens/1/0xEd4064f376cB8d68F770FB1Ff088a3d0F3FF5c4d.json
+++ b/data/tokens/1/0xEd4064f376cB8d68F770FB1Ff088a3d0F3FF5c4d.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This crypto pool contains CRV and ETH. Please be aware that as crypto pools are composed of differently-priced assets, they are subject to impermanent loss.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/crveth/",
   "tokenSymbolOverride": "crvCRVETH",
   "tokenNameOverride": "Curve CRV-ETH Pool"
 }

--- a/data/tokens/1/0xFD5dB7463a3aB53fD211b4af195c5BCCC1A03890.json
+++ b/data/tokens/1/0xFD5dB7463a3aB53fD211b4af195c5BCCC1A03890.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains EURT, a centralized euro stablecoin issued by Tether, and synthetic euro (sEUR) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/eurt",
   "tokenSymbolOverride": "crvEURT",
   "tokenNameOverride": "Curve EURT Pool"
 }

--- a/data/tokens/1/0xFbdCA68601f835b27790D98bbb8eC7f05FDEaA9B.json
+++ b/data/tokens/1/0xFbdCA68601f835b27790D98bbb8eC7f05FDEaA9B.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains sBTC-Crv (sBTC, WBTC, and renBTC) and ibBTC, a yield-bearing synthetic bitcoin from Badger Finance.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/factory/60/",
   "tokenSymbolOverride": "crvIBBTC",
   "tokenNameOverride": "Curve ibBTC Pool"
 }

--- a/data/tokens/1/0xFd2a8fA60Abd58Efe3EeE34dd494cD491dC14900.json
+++ b/data/tokens/1/0xFd2a8fA60Abd58Efe3EeE34dd494cD491dC14900.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, USDC, and USDT that are lent out to Aave, a decentralized money market on Ethereum.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/aave/",
   "tokenSymbolOverride": "crvAAVE",
   "tokenNameOverride": "Curve Aave Pool"
 }

--- a/data/tokens/1/0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf.json
+++ b/data/tokens/1/0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ETH and aETHc, a token that represents staked ether in Ankr StakeFi, an ETH 2.0 staking platform.",
-  "website": "https://curve.fi/factory/56/",
+  "website": "https://curve.fi/ankreth/",
   "tokenSymbolOverride": "crvAETHc",
   "tokenNameOverride": "Curve aETHc Pool"
 }

--- a/data/tokens/1/0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf.json
+++ b/data/tokens/1/0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains ETH and aETHc, a token that represents staked ether in Ankr StakeFi, an ETH 2.0 staking platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/factory/56/",
   "tokenSymbolOverride": "crvAETHc",
   "tokenNameOverride": "Curve aETHc Pool"
 }

--- a/data/tokens/1/0xb19059ebb43466C323583928285a49f558E572Fd.json
+++ b/data/tokens/1/0xb19059ebb43466C323583928285a49f558E572Fd.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains WBTC and HBTC, a tokenized BTC custodied by Huobi.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/hbtc/",
   "tokenSymbolOverride": "crvHBTC",
   "tokenNameOverride": "Curve HBTC Pool"
 }

--- a/data/tokens/1/0xb9446c4Ef5EBE66268dA6700D26f96273DE3d571.json
+++ b/data/tokens/1/0xb9446c4Ef5EBE66268dA6700D26f96273DE3d571.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains agEUR, EURT, and EURS. agEUR is a synthetic Euro issued by [Angle Protocol](https://angle.money), while EURS and EURT are both centralized, hard-pegged Euro tokens issued by Stasis and Tether, respectively.",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/factory/66/",
   "tokenSymbolOverride": "crv3EUR",
   "tokenNameOverride": "Curve 3EUR Pool"
 }

--- a/data/tokens/1/0xc270b3B858c335B6BA5D5b10e2Da8a09976005ad.json
+++ b/data/tokens/1/0xc270b3B858c335B6BA5D5b10e2Da8a09976005ad.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This metapool contains 3Crv (DAI, USDC, and USDT) and USDP (USDPax).",
-  "website": "https://curve.fi",
+  "website": "https://curve.fi/factory/59/",
   "tokenSymbolOverride": "crvUSDPax",
   "tokenNameOverride": "Curve USDPax Pool"
 }

--- a/data/tokens/1/0xc4AD29ba4B3c580e6D59105FFf484999997675Ff.json
+++ b/data/tokens/1/0xc4AD29ba4B3c580e6D59105FFf484999997675Ff.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This crypto pool contains USDT, WBTC, and WETH. Please be aware that as crypto pools are composed of differently-priced assets, they are subject to impermanent loss.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/tricrypto2/",
   "tokenSymbolOverride": "3Crypto",
   "tokenNameOverride": "Curve 3Crypto Pool"
 }

--- a/data/tokens/1/0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF.json
+++ b/data/tokens/1/0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This crypto pool contains USDT, WBTC, and WETH. Please be aware that as crypto pools are composed of differently-priced assets, they are subject to impermanent loss.",
-  "website": "https://www.curve.fi/",
+  "website": "https://curve.fi/tricrypto2",
   "tokenSymbolOverride": "crvTricrypto",
   "tokenNameOverride": "Curve triCrypto Pool"
 }

--- a/data/tokens/1/0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF.json
+++ b/data/tokens/1/0xcA3d75aC011BF5aD07a98d02f18225F9bD9A6BDF.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This crypto pool contains USDT, WBTC, and WETH. Please be aware that as crypto pools are composed of differently-priced assets, they are subject to impermanent loss.",
-  "website": "https://curve.fi/tricrypto2",
+  "website": "https://curve.fi/tricrypto",
   "tokenSymbolOverride": "crvTricrypto",
   "tokenNameOverride": "Curve triCrypto Pool"
 }

--- a/data/tokens/1/0xcee60cFa923170e4f8204AE08B4fA6A3F5656F3a.json
+++ b/data/tokens/1/0xcee60cFa923170e4f8204AE08B4fA6A3F5656F3a.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains LINK and synthetic LINK (sLINK) minted on the Synthetix platform.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/link/",
   "tokenSymbolOverride": "crvLINK",
   "tokenNameOverride": "Curve LINK Pool"
 }

--- a/data/tokens/1/0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B.json
+++ b/data/tokens/1/0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This factory metapool contains 3Crv (DAI, USDC, and USDT) and FRAX, a partially-algorithmic stablecoin.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/frax/",
   "tokenSymbolOverride": "crvFRAX",
   "tokenNameOverride": "Curve FRAX Pool"
 }

--- a/data/tokens/1/0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8.json
+++ b/data/tokens/1/0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains DAI, USDC, USDT, and TUSD that are lent out to various decentralized money markets on Ethereum.",
-  "website": "https://www.curve.fi/",
+  "website": "https://www.curve.fi/iearn/",
   "tokenSymbolOverride": "yCRV",
   "tokenNameOverride": "Curve Y Pool"
 }


### PR DESCRIPTION
Links in "vault descriptions" now go directly to the associated curve pool webpage