### PR TITLE
fix: add yvboost apy override

### DIFF
--- a/data/vaults/1/0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a.json
+++ b/data/vaults/1/0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a.json
@@ -10,5 +10,6 @@
   "allowZapIn": true,
   "allowZapOut": true,
   "retired": false,
-  "displayName": "yvBOOST"
+  "displayName": "yvBOOST",
+  "apyOverride": 0.075
 }


### PR DESCRIPTION
The new yvboost strat donates to the vault rather than harvesting, increasing price per share, but the exporter looks at harvests to calculate apy, of which there are none. It should be harvested a couple of times by the end of the week, then we can remove this