### PR TITLE
fix: remove Arbitrum tricrypto apy override

### DIFF
--- a/data/vaults/42161/0x239e14A19DFF93a17339DCC444f74406C17f8E67.json
+++ b/data/vaults/42161/0x239e14A19DFF93a17339DCC444f74406C17f8E67.json
@@ -4,7 +4,6 @@
   "hideAlways": false,
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
-  "apyTypeOverride": "new",
   "order": 0,
   "migrationAvailable": false,
   "allowZapIn": false,


### PR DESCRIPTION
APY has been new for long enough, APY override may be invalid now.