### PR TITLE
fix: cvx-eth apy override off

### DIFF
--- a/data/vaults/1/0x1635b506a88fBF428465Ad65d00e8d6B6E5846C3.json
+++ b/data/vaults/1/0x1635b506a88fBF428465Ad65d00e8d6B6E5846C3.json
@@ -5,7 +5,7 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 23.5,
-  "apyTypeOverride": "new",
+  //"apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,

--- a/data/vaults/1/0x1635b506a88fBF428465Ad65d00e8d6B6E5846C3.json
+++ b/data/vaults/1/0x1635b506a88fBF428465Ad65d00e8d6B6E5846C3.json
@@ -5,7 +5,6 @@
   "depositsDisabled": false,
   "withdrawalsDisabled": false,
   "order": 23.5,
-  //"apyTypeOverride": "new",
   "migrationAvailable": false,
   "allowZapIn": true,
   "allowZapOut": true,


### PR DESCRIPTION
updating the apy override in cvx-eth to off, has been out long enough likely time to allow it.

left as comment to be easily reversed if calculation is wrong or off.