### PR TITLE
fix: correct mim 2pool website link

### DIFF
--- a/data/tokens/250/0x2dd7C9371965472E5A5fD28fbE165007c61439E1.json
+++ b/data/tokens/250/0x2dd7C9371965472E5A5fD28fbE165007c61439E1.json
@@ -2,7 +2,7 @@
   "$schema": "token",
   "categories": ["Curve LP Tokens"],
   "description": "This token represents a Curve liquidity pool. Holders earn fees from users trading in the pool, and can also deposit the LP to Curve's gauges to earn CRV emissions. This pool contains MIM, fUSDT, and USDC.",
-  "website": "https://ftm.curve.fi/factory/61",
+  "website": "https://ftm.curve.fi/factory/1",
   "tokenSymbolOverride": "crvMIM3Pool",
   "tokenNameOverride": "Curve MIM 3Pool",
   "localization": {


### PR DESCRIPTION
It was pointing to the wrong pool token