### PR TITLE
feat: show apy as opposed to new in non-errored arb vaults

### DIFF
--- a/data/vaults/42161/0x1dBa7641dc69188D6086a73B972aC4bda29Ec35d.json
+++ b/data/vaults/42161/0x1dBa7641dc69188D6086a73B972aC4bda29Ec35d.json
@@ -9,6 +9,5 @@
   "allowZapIn": false,
   "allowZapOut": false,
   "retired": false,
-  "apyTypeOverride": "new",
   "displayName": "Curve MIM 3Pool"
 }

--- a/data/vaults/42161/0x49448d2B94fb9C4e41a30aD8315D32f46004A34b.json
+++ b/data/vaults/42161/0x49448d2B94fb9C4e41a30aD8315D32f46004A34b.json
@@ -9,5 +9,6 @@
   "allowZapIn": false,
   "allowZapOut": false,
   "retired": false,
+  "apyTypeOverride": "new",
   "displayName": "Curve 2Pool"
 }

--- a/data/vaults/42161/0x49448d2B94fb9C4e41a30aD8315D32f46004A34b.json
+++ b/data/vaults/42161/0x49448d2B94fb9C4e41a30aD8315D32f46004A34b.json
@@ -9,6 +9,5 @@
   "allowZapIn": false,
   "allowZapOut": false,
   "retired": false,
-  "apyTypeOverride": "new",
   "displayName": "Curve 2Pool"
 }


### PR DESCRIPTION
These 2 vaults have been successfully harvesting for a while now. It's time we start showing their APYs instead of the *NEW* label in Arbitrum. For the 2CRV vault, the apy.type attribute here -- https://api.yearn.finance/v1/chains/42161/vaults/all --  is showing `error` however, so we must fix that for this change to be successful.  @xgambitox is currently assisting with that.